### PR TITLE
Windows install updated and some fixes

### DIFF
--- a/do
+++ b/do
@@ -63,6 +63,8 @@ def check_jlink():
 #--------------------------------------------------------------------
 
 def find_uart0():
+    if 'uart_name' in settings:
+        return settings['uart_name']
     for port in list_ports.comports():
         if re.search("CP210.+Interface 0", str(port)):
             return port.device
@@ -420,6 +422,9 @@ if __name__ == "__main__":
     parser.add_argument("-u", "--ubxlib-dir",
                         help="Ubxlib directory"
                         )
+    parser.add_argument("--uart-name",
+                        help="Uart port name"
+                        )
     args = parser.parse_args()
 
     if not args.operation[0] in locals():
@@ -448,6 +453,8 @@ if __name__ == "__main__":
     if not args.example in examples:
         error_exit(f"Invalid example \"{args.example}\"\nAvailable: {examples}")
     settings['no_bootloader'] = args.no_bootloader
+    if args.uart_name != None:
+        settings['uart_name'] = args.uart_name
     check_directories()
     set_env()
     state['example'] = args.example

--- a/examples/ble_sps/src/main.c
+++ b/examples/ble_sps/src/main.c
@@ -105,8 +105,4 @@ void main()
     } else {
         printf("* Failed to initiate the module: %d\n", errorCode);
     }
-
-    while (1) {
-        uPortTaskBlock(1000);
-    }
 }

--- a/examples/common/ext_fs.c
+++ b/examples/common/ext_fs.c
@@ -44,14 +44,15 @@ const char *extFsPath(const char *fileName)
     return path;
 }
 
-unsigned long extFsFree()
+int32_t extFsFree()
 {
-    unsigned long free = 0;
+    int32_t errorOrSize;
     struct fs_statvfs sbuf;
-    if (fs_statvfs(gMountPoint->mnt_point, &sbuf) == 0) {
-        free = sbuf.f_frsize * sbuf.f_bfree / 1024;
+    errorOrSize = fs_statvfs(gMountPoint->mnt_point, &sbuf);
+    if (errorOrSize == 0) {
+        errorOrSize = sbuf.f_frsize * sbuf.f_bfree / 1024;
     }
-    return free;
+    return errorOrSize;
 }
 
 bool extFsFileExists(const char *fileName)

--- a/examples/common/ext_fs.h
+++ b/examples/common/ext_fs.h
@@ -37,9 +37,9 @@ const char *extFsPath(const char *fileName);
 
 /**
  * Get the size of the free space on the file system in kB.
- * @return Actual free size.
+ * @return Actual free size or possible negative error code
  */
-unsigned long extFsFree();
+int32_t extFsFree();
 
 /**
  * Check if a file exists

--- a/examples/socket/src/main.c
+++ b/examples/socket/src/main.c
@@ -71,7 +71,7 @@ void main()
         if (errorCode == 0) {
             // Send to and read back data from an echo server using ubxlib sockets
             uSockAddress_t address;
-            uSockGetHostByName(deviceHandle, "ubxlib.it-sgn.u-blox.com",
+            uSockGetHostByName(deviceHandle, "ubxlib.redirectme.net",
                                &(address.ipAddress));
             address.port = 5055;
             int32_t sock = uSockCreate(deviceHandle,


### PR DESCRIPTION
The windows install script has been made more resistant to possible
  interfering existing tool installations and faulty path variable.
New uart name parameter has been added to the do command. This can be used
  if the automatic detection of the XPLR-IOT-1 serial port fails.
The extFsFree function now return possible error code when applicable.
The socket example now has the correct echo server address.