### PR TITLE
Minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ launch.json
 settings.json
 examples/playground/*
 !examples/playground/README.md
+ubxlib_examples_xplr_iot.code-workspace

--- a/README.md
+++ b/README.md
@@ -204,3 +204,6 @@ Please note that this command will only work for examples that has defined CONFI
 
     do flash_net -e ble_ibeacon_z
 
+### Visual Studio Code workspace
+
+Once VS Code has been opened via the **do vscode** command and you want to save your setup of windows etc you can save it as a workspace. The next time you then run this command it will detect the workspace and open it.

--- a/examples/captive_portal/src/main.c
+++ b/examples/captive_portal/src/main.c
@@ -71,8 +71,10 @@ void doConnect()
         ledBlink(GREEN_LED, 250, 250);
         errorCode = uNetworkInterfaceUp(gDeviceHandle, U_NETWORK_TYPE_WIFI, &networkCfg);
     }
-    if (errorCode != 0) {
-        printf("- Failed to bring up WiFi, starting captive portal.");
+    if (errorCode == 0) {
+        printf("Connected to WiFi\n");
+    } else {
+        printf("- Failed to bring up WiFi, starting captive portal.\n");
         printf("Use a phone or PC to connect to the WiFi access point\n");
         printf("with the name \"%s\".\n", PORTAL_NAME);
         ledBlink(BLUE_LED, 250, 250);

--- a/install/README.md
+++ b/install/README.md
@@ -8,11 +8,17 @@ The scripts will also install git and clone the actual repository.
 
 ## Windows
 
-[Click this link](https://github.com/u-blox/ubxlib_examples_xplr_iot/raw/master/install/install_windows.bat) and then chose "Save as" in the browser to download the installation script for Windows. Then right click on the downloaded file and select "Run as administrator". The installation will then start and it is quite a lengthy process, typically ~10 min. **Please avoid** clicking in the window of this operation if you have "Quick Edit" for command windows enabled. Doing so may halt the downloading process which in turn can lead to timeouts and later problems for the installation.
+[Click this link](https://github.com/u-blox/ubxlib_examples_xplr_iot/raw/master/install/install_windows.bat) and then chose "Save as" in the browser to download the installation script for Windows. Please note that depending on which browser you are using there may be an additional *.txt* extension added to the *.bat* file name. In that case remove the *.txt* extension.
 
-The [chocolatey](https://chocolatey.org/) package manager is used for installing the required tools. The required drivers for the XPLR-IOT-1 serial ports will also be installed.
+When the download is complete you also need to unblock the security option which is applied by default to a files downloaded from the network. Right click on the file in the Windows Explorer, select *Properties* in the menu and then check the *Unblock* option.
 
-The examples repository is installed in a sub directory to your home directory named xplriot1\ubxlib_examples_xplr_iot. Start a command prompt and change working directory to this and then you can start the operations described on the main README page.
+Once all this has been done then right click on the file again and select *Run as administrator*. The installation will then start and it is quite a lengthy process, typically ~10 min.
+
+**Please avoid** clicking in the window of this operation if you have *Quick Edit* for command windows enabled. Doing so may halt the downloading process which in turn can lead to timeouts and later problems for the installation.
+
+The [chocolatey](https://chocolatey.org/) package manager is used for installing the required tools. Python 3 will be installed from the standard Python installation repository. The required drivers for the XPLR-IOT-1 serial ports will also be installed.
+
+The examples repository is installed in a sub directory to your home directory named *xplriot1\ubxlib_examples_xplr_iot*. Start a command prompt and change working directory to this and then you can start the operations described on the [main README page](https://github.com/u-blox/ubxlib_examples_xplr_iot).
 
 ![Install log](../readme_images/install_windows.png)
 
@@ -22,4 +28,4 @@ The examples repository is installed in a sub directory to your home directory n
 
 When the installation has completed you should either log out and in again or run "source ~/.profile before doing any further operations related to this repository.
 
-The examples repository is installed in a sub directory to your home directory named ~/xplriot1/ubxlib_examples_xplr_iot. Start a command prompt and change working directory to this and then you can start the operations described in the main README page.
+The examples repository is installed in a sub directory to your home directory named *~/xplriot1/ubxlib_examples_xplr_iot*. Start a command prompt and change working directory to this and then you can start the operations described in the [main README page](https://github.com/u-blox/ubxlib_examples_xplr_iot).


### PR DESCRIPTION
The installation script for Windows has been updated:
  Python is now installed from standard repo instead of chocolatey.
  Some changes to avoid possible path or protection problems.
  Stop installation if an error occurs.
The "do" command has been updated
  It is now possible to save a VS Code workspace in the top directory
    and when that has been done the command will find it and open it
    whenever the "vscode" option has been selected.
  The total elapsed time during a build is now shown.
Some of the README files have been updated with additional information